### PR TITLE
Added dark-light theme toggle feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
+   <button id="theme-toggle">🌙</button>
   <div class="main-container">
     <!-- Tool Header -->
+      
     <header class="tool-header">
       <h1>GitHub Username Generator</h1>
       <p class="tool-subtitle">Find the perfect username for your GitHub profile</p>
+       <!-- Dark/Light Mode Toggle Button -->
+
     </header>
 
     <!-- Dual Panel Layout -->

--- a/script.js
+++ b/script.js
@@ -801,6 +801,30 @@ function initializeApp() {
   
   console.log('GitHub Username Generator initialized successfully!');
   console.log(`API calls remaining: ${getRemainingApiCalls()}/${CONFIG.RATE_LIMIT_PER_HOUR}`);
+
+  // 🌗 Theme Toggle Setup
+const themeToggleBtn = document.getElementById('theme-toggle');
+const savedTheme = localStorage.getItem('theme');
+
+// Page load par theme set karo
+if (savedTheme) {
+  document.documentElement.setAttribute('data-theme', savedTheme);
+  themeToggleBtn.textContent = savedTheme === 'light' ? '🌙' : '☀️';
+} else {
+  // Default dark mode
+  document.documentElement.setAttribute('data-theme', 'dark');
+  themeToggleBtn.textContent = '🌙';
+}
+
+// Button click par toggle
+themeToggleBtn.addEventListener('click', () => {
+  const currentTheme = document.documentElement.getAttribute('data-theme');
+  const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-theme', newTheme);
+  localStorage.setItem('theme', newTheme);
+  themeToggleBtn.textContent = newTheme === 'light' ? '🌙' : '☀️';
+});
+
 }
 
 // Create debounced version of check function

--- a/style.css
+++ b/style.css
@@ -42,6 +42,7 @@ body {
   min-height: 100vh;
   padding: 20px;
   line-height: 1.6;
+   
 }
 
 /* 🌟 Accessibility */
@@ -730,3 +731,41 @@ button.loading::after {
     border-width: 2px;
   }
 }
+/* Light mode overrides */
+[data-theme="light"] {
+  --background-gradient: linear-gradient(135deg, #ffffff, #e0e0e0);
+  --card-background: rgba(255, 255, 255, 0.8);
+  --card-background-hover: rgba(240, 240, 240, 0.9);
+  --border-color: rgba(0,0,0,0.2);
+  --border-color-focus: rgba(0,0,0,0.3);
+  --text-color: #111; 
+  --text-secondary: #333;
+  --text-muted: #555;
+  --shadow-light: 0 4px 12px rgba(0,0,0,0.1);
+  --shadow-medium: 0 8px 18px rgba(0,0,0,0.15);
+  --shadow-heavy: 0 10px 25px rgba(0,0,0,0.2);
+}
+
+#theme-toggle {
+  position: fixed; /* absolute se fixed better, always top-right */
+  top: 20px;
+  right: 20px;
+  z-index: 9999;
+   /* sab content ke upar dikhne ke liye */
+  background: none;
+  border: 2px solid var(--primary-color);
+  border-radius: var(--border-radius-md);
+   width: auto; /* ya fixed width jaise 50px/60px */
+  min-width: 50px;
+  padding: 8px 12px;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--primary-color);
+  transition: all 0.3s ease;
+}
+
+#theme-toggle:hover {
+  background: var(--primary-color);
+  color: var(--text-color);
+}
+


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
This PR adds a dark/light mode toggle button to the site.  
Users can switch between dark and light themes, and their preference is saved in localStorage so it persists after refresh.  

Fixes #3

---

## ✅ Type of Change
- [x] New feature ✨

---

## 📷 Screenshots (if applicable)

| Before | After (Dark) | After (Light) |
|--------|--------------|---------------|
 ![dark
<img width="1366" height="768" alt="Screen Shot 2025-08-23 at 4 32 45 PM" src="https://github.com/user-attachments/assets/158d5a61-3597-44af-a08a-1d1843f065ed" />
]  | ![light
<img width="1366" height="768" alt="Screen Shot 2025-08-23 at 5 56 46 PM" src="https://github.com/user-attachments/assets/ee23a643-ab88-4f2f-86ab-08d72e930a46" />
]  |

---

## 🧪 How Has This Been Tested?
- [x] Local development  
- [x] Manual testing on desktop and mobile (responsive view)  

---

## 💬 Checklist
- [x] I have read the contributing guidelines.  
- [x] My changes do not introduce breaking changes.  
- [x] I have tested this code and reviewed it before submitting.  

---

## 🔗 Related Issues
Closes #3  

---

## 🙋 Additional Comments
- Added smooth CSS transitions for better UX  
- Button shows ☀️ in dark mode and 🌙 in light mode  
- Works on both desktop and mobile layouts
