### PR TITLE
Change button text after generation

### DIFF
--- a/script.js
+++ b/script.js
@@ -507,6 +507,8 @@ async function generateUsernames() {
   const nameInput = document.getElementById('nameInput');
   const generateBtn = document.getElementById('generateBtn');
   const resultsContainer = document.getElementById('results');
+  const btnText = generateBtn.querySelector('.btn-text');
+  const btnIcon = generateBtn.querySelector('.btn-icon');
   
   const name = nameInput.value.trim();
   
@@ -561,6 +563,8 @@ async function generateUsernames() {
     state.isGenerating = false;
     generateBtn.classList.remove('loading');
     generateBtn.disabled = false;
+    btnText.textContent = 'Regenerate Ideas';
+    btnIcon.textContent = '🔄';
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -283,6 +283,10 @@ button.loading .btn-text {
   opacity: 0;
 }
 
+button.loading .btn-icon {
+  display: none;
+}
+
 button.loading::after {
   content: '';
   position: absolute;


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Update the “Generate Ideas ✨” button so that **after generating usernames**, it changes to **“Regenerate Ideas 🔄”**.  

---

## ✅ Type of Change

- [x] New feature ✨
- [ ] Bug fix 🐛
- [ ] Documentation update 📝
- [ ] Refactoring 🔁
- [ ] Performance improvement ⚡
- [ ] Test improvement 🧪
- [ ] Chore or maintenance 🧹
- [ ] Other (please describe): ____________________

---

## 🧪 How Has This Been Tested?

- [x] Local development (manual validation in browser)
- [ ] GitHub Actions / CI
- [x] Manual testing
- [ ] Other (please describe): ____________________

**Steps:**
1. Load the page with the initial button state: “Generate Ideas ✨”.
2. Click the button to trigger `generateUsernames()`.
3. After generation completes, verify button shows “Regenerate Ideas 🔄”.
4. Click again and confirm it remains “Regenerate Ideas 🔄” for subsequent runs.

---

## 💬 Checklist

- [x] I have read the contributing guidelines.
- [x] My changes do not introduce breaking changes.
- [x] I have tested this code and reviewed it before submitting.
- [ ] I have added necessary documentation (if applicable).

---

